### PR TITLE
Provide default argument to prevent error if no options.yml file exists

### DIFF
--- a/manage-ice.rb
+++ b/manage-ice.rb
@@ -59,7 +59,7 @@ def meta_command(meta, command = nil, *args)
 end
 
 begin
-  opts = YAML::load(open('options.yml').read)
+  opts = YAML::load(open('options.yml').read) || {}
   meta = Murmur::Ice::Meta.new opts
   # For a Glacier2 connection:
   # meta = Murmur::Ice::Meta.new "host.com", 4063, "user", "pass"


### PR DESCRIPTION
When running manage-ice.rb in a newly cloned repo no default options.yml is provided. This causes the script to throw an error on the {}.merge(opt) line in the Murmur::Ice::Meta constructor unless the user creates a dummy options.yml with at least one key: value pair despite the constructor providing sensible defaults.
